### PR TITLE
fix: update Open Graph image URLs in layout metadata for cache busting

### DIFF
--- a/e2e/about.test.ts
+++ b/e2e/about.test.ts
@@ -39,7 +39,7 @@ test.describe("About page", () => {
     await expect(video).toBeVisible();
     await expect(video).toHaveAttribute(
       "poster",
-      "https://ik.imagekit.io/fl2lbswwo/easy-invoice-video-placeholder.webp"
+      "https://easy-invoice-pdf-assets.1xeq.workers.dev/easy-invoice-video-placeholder.webp"
     );
     await expect(video).toHaveAttribute("muted");
     await expect(video).toHaveAttribute("loop");

--- a/src/app/[locale]/about/layout.tsx
+++ b/src/app/[locale]/about/layout.tsx
@@ -43,7 +43,7 @@ export async function generateMetadata({
         type: "website",
         images: [
           {
-            url: "https://ik.imagekit.io/fl2lbswwo/opengraph-image.png",
+            url: "https://easy-invoice-pdf-assets.1xeq.workers.dev/easy-invoice-opengraph-image.png?v=1",
             width: 1200,
             height: 630,
             alt: "Free Invoice Generator - A web application offering live preview, open source functionality, and no sign up required",
@@ -57,7 +57,7 @@ export async function generateMetadata({
         creator: "@vlad_sazon",
         images: [
           {
-            url: "https://ik.imagekit.io/fl2lbswwo/opengraph-image.png",
+            url: "https://easy-invoice-pdf-assets.1xeq.workers.dev/easy-invoice-opengraph-image.png?v=1",
             width: 1200,
             height: 630,
             alt: "Free Invoice Generator - A web application offering live preview, open source functionality, and no sign up required",

--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -223,7 +223,7 @@ function HeroSection() {
               <div className="w-full">
                 <Video
                   src={VIDEO_DEMO_URL}
-                  fallbackImg="https://ik.imagekit.io/fl2lbswwo/easy-invoice-video-placeholder.webp"
+                  fallbackImg="https://easy-invoice-pdf-assets.1xeq.workers.dev/easy-invoice-video-placeholder.webp"
                   testId="hero-about-page-video"
                 />
               </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -57,7 +57,7 @@ export const metadata: Metadata = {
     type: "website",
     images: [
       {
-        url: "https://ik.imagekit.io/fl2lbswwo/opengraph-image.png",
+        url: "https://easy-invoice-pdf-assets.1xeq.workers.dev/easy-invoice-opengraph-image.png?v=1",
         width: 1200,
         height: 630,
         alt: "Free Invoice Generator - A web application offering live preview, open source functionality, and no sign up required",
@@ -72,7 +72,7 @@ export const metadata: Metadata = {
     creator: "@vlad_sazon",
     images: [
       {
-        url: "https://ik.imagekit.io/fl2lbswwo/opengraph-image.png",
+        url: "https://easy-invoice-pdf-assets.1xeq.workers.dev/easy-invoice-opengraph-image.png?v=1",
         width: 1200,
         height: 630,
         alt: "Free Invoice Generator - A web application offering live preview, open source functionality, and no sign up required",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,17 +33,17 @@ export const metadata: Metadata = {
   icons: {
     icon: [
       {
-        url: "https://ik.imagekit.io/fl2lbswwo/favicon.ico",
+        url: "https://easy-invoice-pdf-assets.1xeq.workers.dev/favicon.ico",
       },
       {
-        url: "https://ik.imagekit.io/fl2lbswwo/icon.png",
+        url: "https://easy-invoice-pdf-assets.1xeq.workers.dev/icon.png",
         type: "image/png",
         sizes: "96x96",
       },
     ],
     apple: [
       {
-        url: "https://ik.imagekit.io/fl2lbswwo/apple-icon.png",
+        url: "https://easy-invoice-pdf-assets.1xeq.workers.dev/apple-icon.png",
         type: "image/png",
         sizes: "180x180",
       },
@@ -95,7 +95,8 @@ const JSONLD: WithContext<WebSite> = {
     "invoice generator app",
     "free invoice generator",
   ],
-  image: "https://ik.imagekit.io/fl2lbswwo/opengraph-image.png",
+  image:
+    "https://easy-invoice-pdf-assets.1xeq.workers.dev/easy-invoice-opengraph-image.png?v=1",
   mainEntityOfPage: {
     "@type": "SoftwareApplication",
     "@id": `https://easyinvoicepdf.com/`,


### PR DESCRIPTION
- Modified Open Graph image URLs in layout and about page metadata to include a version query parameter for improved cache management and asset updates.