### PR TITLE
feat: enhance changelog update popup functionality

### DIFF
--- a/e2e/about.test.ts
+++ b/e2e/about.test.ts
@@ -6,10 +6,7 @@ import {
   TWITTER_URL,
   VIDEO_DEMO_FALLBACK_IMG,
 } from "@/config";
-import {
-  LANGUAGE_TO_NATIVE_LABEL,
-  SUPPORTED_LANGUAGES,
-} from "@/app/schema";
+import { LANGUAGE_TO_NATIVE_LABEL, SUPPORTED_LANGUAGES } from "@/app/schema";
 import { expect, test } from "@playwright/test";
 
 test.describe("About page", () => {

--- a/src/app/(app)/components/index.tsx
+++ b/src/app/(app)/components/index.tsx
@@ -266,12 +266,12 @@ export function InvoiceClientPage({
             />
           </div>
           {/** Mobile version */}
-          {invoiceLastUpdatedAtFormatted && (
+          {invoiceLastUpdatedAtFormatted ? (
             <div className="relative mt-2 text-center text-xs text-zinc-700 duration-500 animate-in fade-in slide-in-from-bottom-2">
               <span className="font-semibold">Invoice last updated:</span>{" "}
               {invoiceLastUpdatedAtFormatted}
             </div>
-          )}
+          ) : null}
 
           <div
             className="mt-5 flex flex-wrap justify-center gap-1 text-xs text-zinc-900"
@@ -341,14 +341,14 @@ export function InvoiceClientPage({
           </div>
           {/* Invoice preview section i.e. right column (Desktop version) */}
           <div className="relative col-span-8 h-[620px] w-full max-w-full 2xl:h-[700px]">
-            {invoiceLastUpdatedAtFormatted && (
+            {invoiceLastUpdatedAtFormatted ? (
               <div className="relative">
                 <div className="absolute -top-5 right-0 z-10 text-center text-xs text-zinc-700 duration-500 animate-in fade-in slide-in-from-bottom-2 md:-mb-5 lg:text-right">
                   <span className="font-semibold">Invoice last updated:</span>{" "}
                   {invoiceLastUpdatedAtFormatted}
                 </div>
               </div>
-            )}
+            ) : null}
             <PdfViewer
               invoiceData={invoiceDataState}
               errorWhileGeneratingPdfIsShown={errorWhileGeneratingPdfIsShown}

--- a/src/app/(app)/components/invoice-form/index.tsx
+++ b/src/app/(app)/components/invoice-form/index.tsx
@@ -523,9 +523,9 @@ export const InvoiceForm = memo(function InvoiceForm({
                 />
               )}
             />
-            {errors.paymentMethod && (
+            {errors.paymentMethod ? (
               <ErrorMessage>{errors.paymentMethod.message}</ErrorMessage>
-            )}
+            ) : null}
           </div>
         )}
 
@@ -542,9 +542,9 @@ export const InvoiceForm = memo(function InvoiceForm({
                 <Input {...field} id={`paymentDue`} type="date" className="" />
               )}
             />
-            {errors.paymentDue && (
+            {errors.paymentDue ? (
               <ErrorMessage>{errors.paymentDue.message}</ErrorMessage>
-            )}
+            ) : null}
             {!errors.paymentDue &&
             isPaymentDueBeforeDateOfIssue &&
             dateOfIssue ? (
@@ -645,9 +645,9 @@ export const InvoiceForm = memo(function InvoiceForm({
               />
             )}
           />
-          {errors?.notes && (
+          {errors?.notes ? (
             <ErrorMessage>{errors?.notes?.message}</ErrorMessage>
-          )}
+          ) : null}
         </div>
 
         {/* QR Code */}
@@ -703,9 +703,9 @@ export const InvoiceForm = memo(function InvoiceForm({
                 Enter any text or URL to generate a QR code. The QR code will
                 appear in the bottom section of the invoice PDF.
               </InputHelperMessage>
-              {errors.qrCodeData && (
+              {errors.qrCodeData ? (
                 <ErrorMessage>{errors.qrCodeData.message}</ErrorMessage>
-              )}
+              ) : null}
             </div>
 
             {/* QR Code Description */}
@@ -730,9 +730,9 @@ export const InvoiceForm = memo(function InvoiceForm({
                 Optional text that will be displayed below the QR code in the
                 PDF.
               </InputHelperMessage>
-              {errors.qrCodeDescription && (
+              {errors.qrCodeDescription ? (
                 <ErrorMessage>{errors.qrCodeDescription.message}</ErrorMessage>
-              )}
+              ) : null}
             </div>
           </div>
         </fieldset>
@@ -797,11 +797,11 @@ export const InvoiceForm = memo(function InvoiceForm({
                 <InputHelperMessage>
                   Name displayed above the signature line in the PDF.
                 </InputHelperMessage>
-                {errors.personAuthorizedToReceiveName && (
+                {errors.personAuthorizedToReceiveName ? (
                   <ErrorMessage>
                     {errors.personAuthorizedToReceiveName.message}
                   </ErrorMessage>
-                )}
+                ) : null}
               </div>
             </fieldset>
 
@@ -860,11 +860,11 @@ export const InvoiceForm = memo(function InvoiceForm({
                 <InputHelperMessage>
                   Name displayed above the signature line in the PDF.
                 </InputHelperMessage>
-                {errors.personAuthorizedToIssueName && (
+                {errors.personAuthorizedToIssueName ? (
                   <ErrorMessage>
                     {errors.personAuthorizedToIssueName.message}
                   </ErrorMessage>
-                )}
+                ) : null}
               </div>
             </fieldset>
           </>

--- a/src/app/(app)/components/invoice-form/sections/buyer-information.tsx
+++ b/src/app/(app)/components/invoice-form/sections/buyer-information.tsx
@@ -98,9 +98,9 @@ export const BuyerInformation = memo(function BuyerInformation({
                 />
               )}
             />
-            {errors.buyer?.name && (
+            {errors.buyer?.name ? (
               <ErrorMessage>{errors.buyer.name.message}</ErrorMessage>
-            )}
+            ) : null}
           </div>
 
           <div>
@@ -119,9 +119,9 @@ export const BuyerInformation = memo(function BuyerInformation({
                 />
               )}
             />
-            {errors.buyer?.address && (
+            {errors.buyer?.address ? (
               <ErrorMessage>{errors.buyer.address.message}</ErrorMessage>
-            )}
+            ) : null}
           </div>
 
           <div>
@@ -181,11 +181,11 @@ export const BuyerInformation = memo(function BuyerInformation({
                       />
                     )}
                   />
-                  {errors.buyer?.vatNoLabelText && (
+                  {errors.buyer?.vatNoLabelText ? (
                     <ErrorMessage>
                       {errors.buyer.vatNoLabelText.message}
                     </ErrorMessage>
-                  )}
+                  ) : null}
                   {!errors.buyer?.vatNoLabelText && (
                     <InputHelperMessage>
                       Set a custom label (e.g. VAT no, Tax no, etc.)
@@ -211,9 +211,9 @@ export const BuyerInformation = memo(function BuyerInformation({
                       />
                     )}
                   />
-                  {errors.buyer?.vatNo && (
+                  {errors.buyer?.vatNo ? (
                     <ErrorMessage>{errors.buyer.vatNo.message}</ErrorMessage>
-                  )}
+                  ) : null}
                 </div>
               </div>
             </fieldset>
@@ -264,9 +264,9 @@ export const BuyerInformation = memo(function BuyerInformation({
                 />
               )}
             />
-            {errors.buyer?.email && (
+            {errors.buyer?.email ? (
               <ErrorMessage>{errors.buyer.email.message}</ErrorMessage>
-            )}
+            ) : null}
           </div>
 
           {/* Notes */}
@@ -315,9 +315,9 @@ export const BuyerInformation = memo(function BuyerInformation({
                 />
               )}
             />
-            {errors.buyer?.notes && (
+            {errors.buyer?.notes ? (
               <ErrorMessage>{errors.buyer.notes.message}</ErrorMessage>
-            )}
+            ) : null}
           </div>
         </fieldset>
       </AccordionContent>

--- a/src/app/(app)/components/invoice-form/sections/components/buyer/buyer-dialog.tsx
+++ b/src/app/(app)/components/invoice-form/sections/components/buyer/buyer-dialog.tsx
@@ -418,11 +418,11 @@ export function BuyerDialog({
                             />
                           </FormControl>
 
-                          {form.formState.errors.vatNoLabelText && (
+                          {form.formState.errors.vatNoLabelText ? (
                             <FormMessage>
                               {form.formState.errors.vatNoLabelText.message}
                             </FormMessage>
-                          )}
+                          ) : null}
 
                           {!form.formState.errors.vatNoLabelText && (
                             <InputHelperMessage>

--- a/src/app/(app)/components/invoice-form/sections/components/seller/seller-dialog.tsx
+++ b/src/app/(app)/components/invoice-form/sections/components/seller/seller-dialog.tsx
@@ -422,11 +422,11 @@ export function SellerDialog({
                               placeholder="Enter Tax number label"
                             />
                           </FormControl>
-                          {form.formState.errors.vatNoLabelText && (
+                          {form.formState.errors.vatNoLabelText ? (
                             <FormMessage>
                               {form.formState.errors.vatNoLabelText.message}
                             </FormMessage>
-                          )}
+                          ) : null}
 
                           {!form.formState.errors.vatNoLabelText && (
                             <InputHelperMessage>

--- a/src/app/(app)/components/invoice-form/sections/general-information.tsx
+++ b/src/app/(app)/components/invoice-form/sections/general-information.tsx
@@ -439,11 +439,11 @@ export const GeneralInformation = memo(function GeneralInformation({
                   />
                 )}
               />
-              {errors.invoiceNumberObject?.label && (
+              {errors.invoiceNumberObject?.label ? (
                 <ErrorMessage>
                   {errors.invoiceNumberObject.label.message}
                 </ErrorMessage>
-              )}
+              ) : null}
               {!isDefaultInvoiceNumberLabel &&
                 !errors.invoiceNumberObject?.label && (
                   <InputHelperMessage>
@@ -480,11 +480,11 @@ export const GeneralInformation = memo(function GeneralInformation({
                   />
                 )}
               />
-              {errors.invoiceNumberObject?.value && (
+              {errors.invoiceNumberObject?.value ? (
                 <ErrorMessage>
                   {errors.invoiceNumberObject.value.message}
                 </ErrorMessage>
-              )}
+              ) : null}
 
               {!isInvoiceNumberInCurrentMonth &&
                 !errors.invoiceNumberObject?.value && (
@@ -529,9 +529,9 @@ export const GeneralInformation = memo(function GeneralInformation({
               />
             )}
           />
-          {errors.dateOfIssue && (
+          {errors.dateOfIssue ? (
             <ErrorMessage>{errors.dateOfIssue.message}</ErrorMessage>
-          )}
+          ) : null}
           {isDateOfIssueNotToday && !errors.dateOfIssue ? (
             <InputHelperMessage>
               <span className="flex items-center text-amber-800">
@@ -866,9 +866,9 @@ export const GeneralInformation = memo(function GeneralInformation({
               />
             )}
           />
-          {errors.invoiceType && (
+          {errors.invoiceType ? (
             <ErrorMessage>{errors.invoiceType.message}</ErrorMessage>
-          )}
+          ) : null}
         </div>
         {/* Logo Upload */}
         <div className="">

--- a/src/app/(app)/components/invoice-form/sections/invoice-items.tsx
+++ b/src/app/(app)/components/invoice-form/sections/invoice-items.tsx
@@ -156,11 +156,11 @@ export const InvoiceItems = memo(function InvoiceItems({
                     />
                   )}
                 />
-                {errors.items?.[index]?.name && (
+                {errors.items?.[index]?.name ? (
                   <ErrorMessage>
                     {errors.items[index]?.name?.message}
                   </ErrorMessage>
-                )}
+                ) : null}
               </div>
 
               {/* Invoice Item Type of GTU - Only show for default template */}
@@ -219,11 +219,11 @@ export const InvoiceItems = memo(function InvoiceItems({
                       />
                     )}
                   />
-                  {errors.items?.[index]?.typeOfGTU && (
+                  {errors.items?.[index]?.typeOfGTU ? (
                     <ErrorMessage>
                       {errors.items[index]?.typeOfGTU?.message}
                     </ErrorMessage>
-                  )}
+                  ) : null}
                 </div>
               )}
 
@@ -296,11 +296,11 @@ export const InvoiceItems = memo(function InvoiceItems({
                     );
                   }}
                 />
-                {errors.items?.[index]?.amount && (
+                {errors.items?.[index]?.amount ? (
                   <ErrorMessage>
                     {errors.items[index].amount.message}
                   </ErrorMessage>
-                )}
+                ) : null}
               </div>
 
               {/* Invoice Item Unit */}
@@ -354,11 +354,11 @@ export const InvoiceItems = memo(function InvoiceItems({
                     />
                   )}
                 />
-                {errors.items?.[index]?.unit && (
+                {errors.items?.[index]?.unit ? (
                   <ErrorMessage>
                     {errors.items[index].unit.message}
                   </ErrorMessage>
-                )}
+                ) : null}
               </div>
 
               {/* Invoice Item Net Price */}
@@ -451,11 +451,11 @@ export const InvoiceItems = memo(function InvoiceItems({
                   />
                 </div>
 
-                {errors.items?.[index]?.netPrice && (
+                {errors.items?.[index]?.netPrice ? (
                   <ErrorMessage>
                     {errors.items[index].netPrice.message}
                   </ErrorMessage>
-                )}
+                ) : null}
               </div>
 
               {/* Invoice Item Tax Settings */}
@@ -510,9 +510,9 @@ export const InvoiceItems = memo(function InvoiceItems({
                       />
                     )}
                   />
-                  {errors.taxLabelText && (
+                  {errors.taxLabelText ? (
                     <ErrorMessage>{errors.taxLabelText.message}</ErrorMessage>
-                  )}
+                  ) : null}
                   {!errors.taxLabelText && (
                     <InputHelperMessage>
                       Customize the tax label on your invoice (e.g., VAT, Sales

--- a/src/app/(app)/components/invoice-form/sections/seller-information.tsx
+++ b/src/app/(app)/components/invoice-form/sections/seller-information.tsx
@@ -100,9 +100,9 @@ export const SellerInformation = memo(function SellerInformation({
                 />
               )}
             />
-            {errors.seller?.name && (
+            {errors.seller?.name ? (
               <ErrorMessage>{errors.seller.name.message}</ErrorMessage>
-            )}
+            ) : null}
           </div>
 
           <div>
@@ -121,9 +121,9 @@ export const SellerInformation = memo(function SellerInformation({
                 />
               )}
             />
-            {errors.seller?.address && (
+            {errors.seller?.address ? (
               <ErrorMessage>{errors.seller.address.message}</ErrorMessage>
-            )}
+            ) : null}
           </div>
 
           <div>
@@ -183,11 +183,11 @@ export const SellerInformation = memo(function SellerInformation({
                       />
                     )}
                   />
-                  {errors.seller?.vatNoLabelText && (
+                  {errors.seller?.vatNoLabelText ? (
                     <ErrorMessage>
                       {errors.seller.vatNoLabelText.message}
                     </ErrorMessage>
-                  )}
+                  ) : null}
                   {!errors.seller?.vatNoLabelText && (
                     <InputHelperMessage>
                       Set a custom label (e.g. VAT no, Tax no, etc.)
@@ -213,9 +213,9 @@ export const SellerInformation = memo(function SellerInformation({
                       />
                     )}
                   />
-                  {errors.seller?.vatNo && (
+                  {errors.seller?.vatNo ? (
                     <ErrorMessage>{errors.seller.vatNo.message}</ErrorMessage>
-                  )}
+                  ) : null}
                 </div>
               </div>
             </fieldset>
@@ -268,9 +268,9 @@ export const SellerInformation = memo(function SellerInformation({
                 />
               )}
             />
-            {errors.seller?.email && (
+            {errors.seller?.email ? (
               <ErrorMessage>{errors.seller.email.message}</ErrorMessage>
-            )}
+            ) : null}
           </div>
 
           {/* Account Number */}
@@ -322,9 +322,9 @@ export const SellerInformation = memo(function SellerInformation({
                 />
               )}
             />
-            {errors.seller?.accountNumber && (
+            {errors.seller?.accountNumber ? (
               <ErrorMessage>{errors.seller.accountNumber.message}</ErrorMessage>
-            )}
+            ) : null}
           </div>
 
           {/* SWIFT/BIC */}
@@ -375,9 +375,9 @@ export const SellerInformation = memo(function SellerInformation({
                 />
               )}
             />
-            {errors.seller?.swiftBic && (
+            {errors.seller?.swiftBic ? (
               <ErrorMessage>{errors.seller.swiftBic.message}</ErrorMessage>
-            )}
+            ) : null}
           </div>
 
           {/* Notes */}
@@ -427,9 +427,9 @@ export const SellerInformation = memo(function SellerInformation({
                 />
               )}
             />
-            {errors.seller?.notes && (
+            {errors.seller?.notes ? (
               <ErrorMessage>{errors.seller.notes.message}</ErrorMessage>
-            )}
+            ) : null}
           </div>
         </fieldset>
       </AccordionContent>

--- a/src/app/(app)/hooks/__tests__/use-changelog-update-popup.test.ts
+++ b/src/app/(app)/hooks/__tests__/use-changelog-update-popup.test.ts
@@ -1,0 +1,220 @@
+// @vitest-environment happy-dom
+
+import type { ChangelogSummary } from "@/app/changelog/utils";
+import { shouldShowChangelogPopup } from "@/app/(app)/utils/changelog-seen-storage";
+import { hasSeenWelcomePopup } from "@/app/(app)/utils/welcome-popup-seen-storage";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useChangelogUpdatePopup } from "../use-changelog-update-popup";
+
+vi.mock("@/app/(app)/utils/welcome-popup-seen-storage", () => ({
+  hasSeenWelcomePopup: vi.fn(),
+}));
+
+vi.mock("@/app/(app)/utils/changelog-seen-storage", () => ({
+  shouldShowChangelogPopup: vi.fn(),
+}));
+
+const latestChangelog: ChangelogSummary = {
+  slug: "v1-0-3",
+  title: "Version 1.0.3",
+  description: "Latest release",
+  version: "1.0.3",
+  date: "2026-07-01",
+};
+
+function renderChangelogPopupHook(
+  overrides: Partial<{
+    latestChangelog: ChangelogSummary | null;
+    isViewingSharedInvoice: boolean;
+    isMobile: boolean;
+  }> = {},
+) {
+  return renderHook(() =>
+    useChangelogUpdatePopup({
+      latestChangelog: null,
+      isViewingSharedInvoice: false,
+      isMobile: false,
+      ...overrides,
+    }),
+  );
+}
+
+describe("useChangelogUpdatePopup", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.mocked(hasSeenWelcomePopup).mockReturnValue(false);
+    vi.mocked(shouldShowChangelogPopup).mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("should show welcome popup on first visit after delay", () => {
+    const { result } = renderChangelogPopupHook();
+
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.variant).toBe(null);
+
+    act(() => {
+      vi.advanceTimersByTime(1_500);
+    });
+
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.variant).toBe("welcome");
+    expect(result.current.latestChangelog).toBe(null);
+  });
+
+  it("should not show changelog in same session after welcome was shown", () => {
+    const { result, rerender } = renderHook(
+      ({ latest }) =>
+        useChangelogUpdatePopup({
+          latestChangelog: latest,
+          isViewingSharedInvoice: false,
+          isMobile: false,
+        }),
+      { initialProps: { latest: null as ChangelogSummary | null } },
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(1_500);
+    });
+
+    expect(result.current.variant).toBe("welcome");
+
+    vi.mocked(hasSeenWelcomePopup).mockReturnValue(true);
+
+    act(() => {
+      result.current.dismiss();
+    });
+
+    rerender({ latest: latestChangelog });
+
+    act(() => {
+      vi.advanceTimersByTime(1_500);
+    });
+
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.variant).toBe(null);
+  });
+
+  it("should show changelog popup on a return visit", () => {
+    vi.mocked(hasSeenWelcomePopup).mockReturnValue(true);
+
+    const { result } = renderChangelogPopupHook({ latestChangelog });
+
+    act(() => {
+      vi.advanceTimersByTime(1_500);
+    });
+
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.variant).toBe("changelog");
+    expect(result.current.latestChangelog).toEqual(latestChangelog);
+  });
+
+  it("should show changelog popup when latest changelog slug changes", () => {
+    vi.mocked(hasSeenWelcomePopup).mockReturnValue(true);
+
+    const previousChangelog: ChangelogSummary = {
+      ...latestChangelog,
+      slug: "v1-0-2",
+      title: "Version 1.0.2",
+      version: "1.0.2",
+    };
+
+    const newChangelog: ChangelogSummary = {
+      ...latestChangelog,
+      slug: "v1-0-4",
+      title: "Version 1.0.4",
+      version: "1.0.4",
+    };
+
+    vi.mocked(shouldShowChangelogPopup).mockImplementation(
+      (slug) => slug === newChangelog.slug,
+    );
+
+    const { result, rerender } = renderHook(
+      ({ latest }) =>
+        useChangelogUpdatePopup({
+          latestChangelog: latest,
+          isViewingSharedInvoice: false,
+          isMobile: false,
+        }),
+      { initialProps: { latest: previousChangelog } },
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(1_500);
+    });
+
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.variant).toBe(null);
+
+    rerender({ latest: newChangelog });
+
+    act(() => {
+      vi.advanceTimersByTime(1_500);
+    });
+
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.variant).toBe("changelog");
+    expect(result.current.latestChangelog).toEqual(newChangelog);
+  });
+
+  it("should not show popup when changelog was already seen", () => {
+    vi.mocked(hasSeenWelcomePopup).mockReturnValue(true);
+    vi.mocked(shouldShowChangelogPopup).mockReturnValue(false);
+
+    const { result } = renderChangelogPopupHook({ latestChangelog });
+
+    act(() => {
+      vi.advanceTimersByTime(1_500);
+    });
+
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.variant).toBe(null);
+  });
+
+  it("should not show popup on mobile", () => {
+    const { result } = renderChangelogPopupHook({ isMobile: true });
+
+    act(() => {
+      vi.advanceTimersByTime(1_500);
+    });
+
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.variant).toBe(null);
+  });
+
+  it("should not show popup when viewing a shared invoice", () => {
+    const { result } = renderChangelogPopupHook({
+      isViewingSharedInvoice: true,
+      latestChangelog,
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1_500);
+    });
+
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.variant).toBe(null);
+  });
+
+  it("should close popup when dismissed", () => {
+    const { result } = renderChangelogPopupHook();
+
+    act(() => {
+      vi.advanceTimersByTime(1_500);
+    });
+
+    expect(result.current.isOpen).toBe(true);
+
+    act(() => {
+      result.current.dismiss();
+    });
+
+    expect(result.current.isOpen).toBe(false);
+  });
+});

--- a/src/app/(app)/hooks/__tests__/use-show-random-cta-toast.test.ts
+++ b/src/app/(app)/hooks/__tests__/use-show-random-cta-toast.test.ts
@@ -1,0 +1,208 @@
+// @vitest-environment happy-dom
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { showRandomCTAToast } from "../../components/cta-toasts";
+import { useCTAToast } from "../../contexts/cta-toast-context";
+import { useShowRandomCTAToastOnIdle } from "../use-show-random-cta-toast";
+
+vi.mock("../../components/cta-toasts", () => ({
+  showRandomCTAToast: vi.fn(),
+}));
+
+vi.mock("../../contexts/cta-toast-context", () => ({
+  useCTAToast: vi.fn(),
+}));
+
+const MIN_TIME_ON_PAGE = 7_000;
+const IDLE_TIME = 5_000;
+
+interface CTAToastState {
+  hasTriggeredCTAAction: boolean;
+  interactionCount: number;
+}
+
+function renderIdleToastHook(initialState: Partial<CTAToastState> = {}) {
+  const markCTAActionTriggered = vi.fn();
+  const state: CTAToastState = {
+    hasTriggeredCTAAction: false,
+    interactionCount: 0,
+    ...initialState,
+  };
+
+  vi.mocked(useCTAToast).mockImplementation(() => ({
+    hasTriggeredCTAAction: state.hasTriggeredCTAAction,
+    markCTAActionTriggered,
+    interactionCount: state.interactionCount,
+    incrementInteractionCount: vi.fn(),
+  }));
+
+  const hook = renderHook(() => useShowRandomCTAToastOnIdle());
+
+  return {
+    ...hook,
+    markCTAActionTriggered,
+    setInteractionCount(count: number) {
+      state.interactionCount = count;
+      hook.rerender();
+    },
+    setHasTriggeredCTAAction(value: boolean) {
+      state.hasTriggeredCTAAction = value;
+      hook.rerender();
+    },
+  };
+}
+
+describe("useShowRandomCTAToastOnIdle", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("should show toast after min time on page, enough interactions, and idle period", () => {
+    const { markCTAActionTriggered, setInteractionCount } =
+      renderIdleToastHook();
+
+    act(() => {
+      vi.advanceTimersByTime(MIN_TIME_ON_PAGE);
+    });
+
+    setInteractionCount(3);
+
+    act(() => {
+      vi.advanceTimersByTime(IDLE_TIME);
+    });
+
+    expect(showRandomCTAToast).toHaveBeenCalledTimes(1);
+    expect(markCTAActionTriggered).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not show toast when user has fewer than 3 interactions", () => {
+    const { setInteractionCount } = renderIdleToastHook();
+
+    act(() => {
+      vi.advanceTimersByTime(MIN_TIME_ON_PAGE);
+    });
+
+    setInteractionCount(2);
+
+    act(() => {
+      vi.advanceTimersByTime(IDLE_TIME);
+    });
+
+    expect(showRandomCTAToast).not.toHaveBeenCalled();
+  });
+
+  it("should not show toast when CTA action was already triggered this session", () => {
+    renderIdleToastHook({
+      hasTriggeredCTAAction: true,
+      interactionCount: 3,
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(MIN_TIME_ON_PAGE + IDLE_TIME);
+    });
+
+    expect(showRandomCTAToast).not.toHaveBeenCalled();
+  });
+
+  it("should not show toast when idle period ends before min time on page elapses", () => {
+    const { setInteractionCount } = renderIdleToastHook();
+
+    setInteractionCount(3);
+
+    act(() => {
+      vi.advanceTimersByTime(IDLE_TIME);
+    });
+
+    expect(showRandomCTAToast).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(MIN_TIME_ON_PAGE - IDLE_TIME);
+    });
+
+    expect(showRandomCTAToast).not.toHaveBeenCalled();
+  });
+
+  it("should show toast after min time elapses if user becomes idle again", () => {
+    const { markCTAActionTriggered, setInteractionCount } =
+      renderIdleToastHook();
+
+    setInteractionCount(3);
+
+    act(() => {
+      vi.advanceTimersByTime(IDLE_TIME);
+    });
+
+    expect(showRandomCTAToast).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(MIN_TIME_ON_PAGE - IDLE_TIME);
+    });
+
+    setInteractionCount(4);
+
+    act(() => {
+      vi.advanceTimersByTime(IDLE_TIME);
+    });
+
+    expect(showRandomCTAToast).toHaveBeenCalledTimes(1);
+    expect(markCTAActionTriggered).toHaveBeenCalledTimes(1);
+  });
+
+  it("should reset idle timer when interaction count changes", () => {
+    const { setInteractionCount } = renderIdleToastHook();
+
+    act(() => {
+      vi.advanceTimersByTime(MIN_TIME_ON_PAGE);
+    });
+
+    setInteractionCount(3);
+
+    act(() => {
+      vi.advanceTimersByTime(IDLE_TIME - 1_000);
+    });
+
+    setInteractionCount(4);
+
+    act(() => {
+      vi.advanceTimersByTime(IDLE_TIME - 1_000);
+    });
+
+    expect(showRandomCTAToast).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+
+    expect(showRandomCTAToast).toHaveBeenCalledTimes(1);
+  });
+
+  it("should only show toast once", () => {
+    const { setInteractionCount } = renderIdleToastHook();
+
+    act(() => {
+      vi.advanceTimersByTime(MIN_TIME_ON_PAGE);
+    });
+
+    setInteractionCount(3);
+
+    act(() => {
+      vi.advanceTimersByTime(IDLE_TIME);
+    });
+
+    expect(showRandomCTAToast).toHaveBeenCalledTimes(1);
+
+    setInteractionCount(5);
+
+    act(() => {
+      vi.advanceTimersByTime(IDLE_TIME);
+    });
+
+    expect(showRandomCTAToast).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/(app)/hooks/use-changelog-update-popup.ts
+++ b/src/app/(app)/hooks/use-changelog-update-popup.ts
@@ -46,8 +46,8 @@ function resolvePopupVariant(
  * Hook to manage showing welcome or changelog update popup to user.
  *
  * Shows welcome popup on first visit, then changelog popup when a new
- * changelog version is unseen. Never shows in CI, on mobile, or when
- * viewing a shared invoice.
+ * changelog version is unseen. Never shows on mobile or when viewing a
+ * shared invoice.
  */
 export function useChangelogUpdatePopup({
   latestChangelog,
@@ -65,8 +65,8 @@ export function useChangelogUpdatePopup({
   }, []);
 
   useEffect(() => {
-    // Never show popup in CI or on mobile, unmount if these become true
-    if (process.env.CI || isMobile) {
+    // Never show popup on mobile
+    if (isMobile) {
       setIsMounted(false);
       setIsOpen(false);
       setVariant(null);

--- a/src/app/(app)/hooks/use-changelog-update-popup.ts
+++ b/src/app/(app)/hooks/use-changelog-update-popup.ts
@@ -3,7 +3,7 @@
 import type { ChangelogSummary } from "@/app/changelog/utils";
 import { shouldShowChangelogPopup } from "@/app/(app)/utils/changelog-seen-storage";
 import { hasSeenWelcomePopup } from "@/app/(app)/utils/welcome-popup-seen-storage";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 /** Wait before showing so the page can settle first */
 const SHOW_DELAY_MS = 1_500;
@@ -25,9 +25,14 @@ interface UseChangelogUpdatePopupResult {
 
 function resolvePopupVariant(
   latestChangelog: ChangelogSummary | null,
+  skipChangelogThisSession: boolean,
 ): AppUpdatePopupVariant | null {
   if (!hasSeenWelcomePopup()) {
     return "welcome";
+  }
+
+  if (skipChangelogThisSession) {
+    return null;
   }
 
   if (latestChangelog && shouldShowChangelogPopup(latestChangelog.slug)) {
@@ -52,6 +57,8 @@ export function useChangelogUpdatePopup({
   const [isOpen, setIsOpen] = useState(false);
   const [variant, setVariant] = useState<AppUpdatePopupVariant | null>(null);
   const [isMounted, setIsMounted] = useState(false);
+  /** Blocks changelog popup in same session after welcome was shown */
+  const skipChangelogThisSessionRef = useRef(false);
 
   const dismiss = useCallback(() => {
     setIsOpen(false);
@@ -72,7 +79,10 @@ export function useChangelogUpdatePopup({
     }
 
     // Determine which popup (welcome/changelog) to show, if any
-    const nextVariant = resolvePopupVariant(latestChangelog);
+    const nextVariant = resolvePopupVariant(
+      latestChangelog,
+      skipChangelogThisSessionRef.current,
+    );
 
     // If no popup needed, reset state and exit
     if (!nextVariant) {
@@ -84,6 +94,10 @@ export function useChangelogUpdatePopup({
 
     // Delay showing the popup for a nicer UX
     const timer = window.setTimeout(() => {
+      if (nextVariant === "welcome") {
+        skipChangelogThisSessionRef.current = true;
+      }
+
       setVariant(nextVariant);
       setIsMounted(true);
       setIsOpen(true);

--- a/src/app/changelog/[slug]/page.tsx
+++ b/src/app/changelog/[slug]/page.tsx
@@ -270,7 +270,7 @@ export default async function ChangelogEntryPage({
           </article>
 
           {/* Previous and Next post navigation */}
-          {(previousEntry || nextEntry) && (
+          {previousEntry || nextEntry ? (
             <div className="mt-16 border-t border-gray-200 pt-8 dark:border-gray-700">
               <div className="flex flex-row gap-8 sm:justify-between">
                 {/* Previous post link */}
@@ -315,7 +315,7 @@ export default async function ChangelogEntryPage({
                 )}
               </div>
             </div>
-          )}
+          ) : null}
         </div>
       </div>
     </>

--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -320,9 +320,9 @@ export const MultiSelect = React.forwardRef<
                       >
                         <CheckIcon className="h-4 w-4" />
                       </div>
-                      {option.icon && (
+                      {option.icon ? (
                         <option.icon className="mr-2 h-4 w-4 text-gray-500" />
-                      )}
+                      ) : null}
                       <span>{option.label}</span>
                     </CommandItem>
                   );

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -40,9 +40,9 @@ const TooltipContent = React.memo(
         {...props}
       >
         {props.children}
-        {showArrow && (
+        {showArrow ? (
           <TooltipPrimitive.Arrow className="my-px border-slate-200 fill-white drop-shadow-[0_1px_0_hsl(var(--border))]" />
-        )}
+        ) : null}
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   )),


### PR DESCRIPTION
- For Better UX I added a mechanism to skip the changelog popup in the same session after the welcome popup is shown.
- Introduced a new test suite for the useChangelogUpdatePopup hook to ensure correct behavior across various scenarios, including welcome and changelog visibility based on user interactions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented the changelog popup from reappearing in the same session after the welcome popup is shown and dismissed.
  - Improved popup eligibility rules to better respect mobile and shared-invoice contexts, while preserving first-visit vs. return-visit behavior.
  - Kept popup dismissal behavior consistent.
- **Tests**
  - Added coverage for welcome/changelog popup timing, session behavior, and dismissal.
  - Added coverage for idle-based random CTA toast display rules (including shown-only-once per session).
- **Refactor**
  - Standardized conditional rendering for form validation messages and select/tooltip/icon UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->