### PR TITLE
refactor: streamline service period handling in invoice form tests and components

### DIFF
--- a/e2e/invoice-form.test.ts
+++ b/e2e/invoice-form.test.ts
@@ -1953,6 +1953,16 @@ test.describe("Invoice Generator Page", () => {
       }),
     ).toHaveValue("2025-06-20");
 
+    // filling the dates never touches the PDF visibility switch
+    await expect(servicePeriodSwitch).not.toBeChecked();
+
+    await servicePeriodSwitch.click();
+    await expect(servicePeriodSwitch).toBeChecked();
+
+    // ...and neither does editing them afterwards, in either direction
+    await servicePeriodFieldset
+      .getByRole("textbox", { name: "Service period start" })
+      .fill("2025-06-15");
     await expect(servicePeriodSwitch).toBeChecked();
 
     await servicePeriodSwitch.click();
@@ -1960,47 +1970,8 @@ test.describe("Invoice Generator Page", () => {
 
     await servicePeriodFieldset
       .getByRole("textbox", { name: "Service period start" })
-      .fill("2025-06-15");
-    await expect(servicePeriodSwitch).toBeChecked();
-  });
-
-  test("does not auto-enable service period PDF field when start is the first day of its month", async ({
-    page,
-  }) => {
-    await page.clock.setSystemTime(new Date("2025-06-15T12:00:00Z"));
-
-    await page.goto("/?template=default");
-    await expect(page).toHaveURL("/?template=default");
-
-    const generalInfoSection = page.getByRole("region", {
-      name: "General Information",
-    });
-    const servicePeriodFieldset = generalInfoSection.getByRole("group", {
-      name: "Service period",
-    });
-    const servicePeriodStartInput = servicePeriodFieldset.getByRole("textbox", {
-      name: "Service period start",
-    });
-    const servicePeriodSwitch = servicePeriodFieldset.getByRole("switch", {
-      name: 'Show the "Service period" (Service period start and end) field in the PDF',
-    });
-
+      .fill("2025-06-16");
     await expect(servicePeriodSwitch).not.toBeChecked();
-
-    // First day of the current month should not auto-enable the PDF field.
-    await servicePeriodStartInput.fill("2025-06-01");
-    await expect(servicePeriodStartInput).toHaveValue("2025-06-01");
-    await expect(servicePeriodSwitch).not.toBeChecked();
-
-    // First day of a different month should also stay off (regression for current-month check).
-    await servicePeriodStartInput.fill("2025-05-01");
-    await expect(servicePeriodStartInput).toHaveValue("2025-05-01");
-    await expect(servicePeriodSwitch).not.toBeChecked();
-
-    // Partial month start should still auto-enable the PDF field.
-    await servicePeriodStartInput.fill("2025-05-11");
-    await expect(servicePeriodStartInput).toHaveValue("2025-05-11");
-    await expect(servicePeriodSwitch).toBeChecked();
   });
 
   test("validates service period start is on or before end date", async ({

--- a/e2e/invoice-templates-common/shared-template-features.test.ts
+++ b/e2e/invoice-templates-common/shared-template-features.test.ts
@@ -42,6 +42,21 @@ async function selectTemplate(page: Page, template: Template) {
 }
 
 /**
+ * Selecting the Stripe template turns the "Service period" PDF field on; the default
+ * template leaves it off, so there it has to be switched on by hand.
+ */
+async function showServicePeriodInPdf(
+  servicePeriodSwitch: Locator,
+  template: Template,
+) {
+  if (template === "default") {
+    await servicePeriodSwitch.click();
+  }
+
+  await expect(servicePeriodSwitch).toBeChecked();
+}
+
+/**
  * The "Service period"/"Date of sales" PDF label inputs only exist for the default
  * template — the Stripe PDF template does not print these labels at all.
  */
@@ -361,7 +376,8 @@ test.describe("Invoice Template shared features", () => {
           name: "Service period end",
         }),
       ).toHaveValue(SERVICE_PERIOD_TEST_DATA.end);
-      await expect(servicePeriodSwitch).toBeChecked();
+
+      await showServicePeriodInPdf(servicePeriodSwitch, template);
 
       await expectPdfScreenshot(page, {
         downloadDir,

--- a/e2e/stripe-invoice-template/stripe-invoice-template.test.ts
+++ b/e2e/stripe-invoice-template/stripe-invoice-template.test.ts
@@ -757,6 +757,47 @@ test.describe("Stripe Invoice Template", () => {
     await expect(paymentMethodVisibilitySwitch).toBeChecked(); // Should maintain its state
   });
 
+  test("shows the service period in the PDF for Stripe and hides it for default", async ({
+    page,
+  }) => {
+    await expect(page).toHaveURL("/?template=default");
+
+    const templateCombobox = page.getByRole("combobox", {
+      name: "Invoice Template",
+    });
+    const servicePeriodSwitch = page
+      .getByRole("group", { name: "Service period" })
+      .getByRole("switch", {
+        name: 'Show the "Service period" (Service period start and end) field in the PDF',
+      });
+
+    // the default template hides the service period
+    await expect(servicePeriodSwitch).not.toBeChecked();
+
+    await templateCombobox.selectOption("stripe");
+    await page.waitForURL("/?template=stripe");
+
+    await expect(servicePeriodSwitch).toBeChecked();
+
+    // switching back restores the default template's own behaviour
+    await templateCombobox.selectOption("default");
+    await page.waitForURL("/?template=default");
+
+    await expect(servicePeriodSwitch).not.toBeChecked();
+
+    // an explicit choice on the default template survives until the template changes again
+    await servicePeriodSwitch.click();
+    await expect(servicePeriodSwitch).toBeChecked();
+
+    await templateCombobox.selectOption("stripe");
+    await page.waitForURL("/?template=stripe");
+    await expect(servicePeriodSwitch).toBeChecked();
+
+    await templateCombobox.selectOption("default");
+    await page.waitForURL("/?template=default");
+    await expect(servicePeriodSwitch).not.toBeChecked();
+  });
+
   test("automatically sets date format when switching to Stripe template", async ({
     page,
     browserName,

--- a/src/app/(app)/components/invoice-form/sections/general-information.tsx
+++ b/src/app/(app)/components/invoice-form/sections/general-information.tsx
@@ -22,7 +22,6 @@ import {
 import { formatTodayWithLocale } from "@/app/(app)/utils/format-date-with-locale";
 import {
   getCurrentMonthAndYear,
-  isFirstDayOfMonth,
   isServicePeriodStartInCurrentMonth,
 } from "@/app/(app)/utils/format-service-period";
 import {
@@ -246,9 +245,7 @@ export const GeneralInformation = memo(function GeneralInformation({
 
                       // Set service period field to be VISIBLE for Stripe template (for backwards compatibility)
                       setValue("servicePeriodFieldIsVisible", true);
-                    } else {
-                      // DEFAULT TEMPLATE
-
+                    } else if (newTemplate === "default") {
                       // Clear Stripe-specific fields when not using Stripe template
                       if (errors.stripePayOnlineUrl) {
                         setValue("stripePayOnlineUrl", "");
@@ -259,6 +256,9 @@ export const GeneralInformation = memo(function GeneralInformation({
 
                       // Set unit field to be VISIBLE for default template
                       setValue("items.0.unitFieldIsVisible", true);
+
+                      // Set service period field to be HIDDEN for default template (matches the default template behaviour)
+                      setValue("servicePeriodFieldIsVisible", false);
                     }
                   }}
                 >
@@ -653,19 +653,6 @@ export const GeneralInformation = memo(function GeneralInformation({
                       className={inputErrorClassName(
                         !!errors.dateOfServiceStart,
                       )}
-                      onChange={(e) => {
-                        field.onChange(e);
-
-                        const newServicePeriodStartDate = e.target.value;
-
-                        // auto-show "Service period" in PDF when start date is not first day of its month
-                        if (
-                          newServicePeriodStartDate &&
-                          !isFirstDayOfMonth(newServicePeriodStartDate)
-                        ) {
-                          setValue("servicePeriodFieldIsVisible", true);
-                        }
-                      }}
                     />
                   );
                 }}

--- a/src/app/(app)/utils/__tests__/format-service-period.test.ts
+++ b/src/app/(app)/utils/__tests__/format-service-period.test.ts
@@ -5,7 +5,6 @@ import {
   formatServicePeriodRange,
   getCurrentMonthAndYear,
   getServicePeriod,
-  isFirstDayOfMonth,
   isServicePeriodStartInCurrentMonth,
 } from "@/app/(app)/utils/format-service-period";
 import type { InvoiceData } from "@/app/schema";
@@ -45,18 +44,6 @@ describe("format-service-period", () => {
       } as InvoiceData);
 
       expect(result).toBe("2025-06-20");
-    });
-  });
-
-  describe("isFirstDayOfMonth", () => {
-    it("should return true for the first day of any month", () => {
-      expect(isFirstDayOfMonth("2026-05-01")).toBe(true);
-      expect(isFirstDayOfMonth("2025-12-01")).toBe(true);
-    });
-
-    it("should return false for non-first days regardless of current month", () => {
-      expect(isFirstDayOfMonth("2026-05-11")).toBe(false);
-      expect(isFirstDayOfMonth("2025-06-14")).toBe(false);
     });
   });
 

--- a/src/app/(app)/utils/format-service-period.ts
+++ b/src/app/(app)/utils/format-service-period.ts
@@ -37,17 +37,6 @@ export function formatDateOfServiceEnd(invoiceData: InvoiceData): string {
 }
 
 /**
- * Check if given date is the first day of its own month.
- * @param date - ISO date string.
- * @returns True if date is the first day of its month.
- */
-export function isFirstDayOfMonth(date: string): boolean {
-  const parsed = dayjs(date);
-
-  return parsed.isSame(parsed.startOf("month"), "day");
-}
-
-/**
  * Check if given dateOfServiceStart is in the current calendar month.
  * @param dateOfServiceStart - ISO date string.
  * @returns True if date is in the current month and year.


### PR DESCRIPTION
- Updated invoice form tests to ensure the service period visibility switch behaves correctly when changing dates and templates.
- Introduced a utility function to manage the service period visibility in PDFs based on the selected template.
- Removed redundant checks and improved clarity in the service period logic within the GeneralInformation component.
- Eliminated the isFirstDayOfMonth utility function as it was no longer needed, simplifying the date handling logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Service period PDF visibility is no longer automatically enabled when entering or editing service dates.
  - Switching to the Stripe invoice template enables the Service period field, while returning to the default template hides it.
  - Manually changing the Service period visibility on the default template remains effective until the invoice template is changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->